### PR TITLE
Enable Tomcat's MBean registry for JMX-based Tomcat metrics

### DIFF
--- a/prometheus-tomcat-metrics/src/main/resources/application.properties
+++ b/prometheus-tomcat-metrics/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 management.endpoints.web.exposure.include=*
+
+server.tomcat.mbeanregistry.enabled=true


### PR DESCRIPTION
This PR changes to enable Tomcat's MBean registry for JMX-based Tomcat metrics.